### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,22 +1,22 @@
 pelican:
-  notify:         piergiorgio@apache.org
-  autobuild:      preview/*
-  target:         asf-staging
-  whoami:         main
-  theme:          theme/apache
-  
+  notify: piergiorgio@apache.org
+  autobuild: preview/*
+  target: asf-staging
+  whoami: main
+  theme: theme/apache
+
 staging:
   whoami: asf-staging
-  profile: ~
+  profile:
   autostage: preview/*
 
 publish:
-  profile: ~
+  profile:
   whoami: asf-site
 
 github:
-  description:   "Apache ManifoldCF website"
-  homepage:      https://manifoldcf.apache.org/
+  description: "Apache ManifoldCF website"
+  homepage: https://manifoldcf.apache.org/
   autolink_jira:
     - CONNECTORS
   custom_subjects:
@@ -37,9 +37,22 @@ github:
     - pelican
     - manifoldcf
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  commits:              commits@manifoldcf.apache.org
-  pullrequests:         dev@manifoldcf.apache.org
-  issues:               dev@manifoldcf.apache.org
-  discussions:          dev@manifoldcf.apache.org
+  commits: commits@manifoldcf.apache.org
+  pullrequests: dev@manifoldcf.apache.org
+  issues: dev@manifoldcf.apache.org
+  discussions: dev@manifoldcf.apache.org
   pullrequests_bot_dependabot: dev@manifoldcf.apache.org


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
